### PR TITLE
feat(qa): RSS retry logic and error handling improvements

### DIFF
--- a/archiveinator/steps/page_load.py
+++ b/archiveinator/steps/page_load.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import TimeoutError as PlaywrightTimeout
 from playwright.async_api import async_playwright
 
@@ -70,16 +71,19 @@ async def run(ctx: ArchiveContext) -> None:
                     wait_until="networkidle",
                     timeout=timeout_ms,
                 )
-            except PlaywrightTimeout:
-                console.warning("networkidle timed out, falling back to domcontentloaded")
-                try:
-                    response = await page.goto(
-                        ctx.url,
-                        wait_until="domcontentloaded",
-                        timeout=timeout_ms,
-                    )
-                except PlaywrightTimeout as exc:
-                    raise PageLoadError(f"Timed out loading {ctx.url}") from exc
+            except PlaywrightError as exc:
+                if isinstance(exc, PlaywrightTimeout):
+                    console.warning("networkidle timed out, falling back to domcontentloaded")
+                    try:
+                        response = await page.goto(
+                            ctx.url,
+                            wait_until="domcontentloaded",
+                            timeout=timeout_ms,
+                        )
+                    except PlaywrightTimeout as exc2:
+                        raise PageLoadError(f"Timed out loading {ctx.url}") from exc2
+                else:
+                    raise PageLoadError(f"Playwright error loading {ctx.url}: {exc}") from exc
 
             if response is None:
                 raise PageLoadError(f"No response received for {ctx.url}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "mypy>=1.10.0",
     "types-PyYAML>=6.0.0",
     "types-beautifulsoup4>=4.12.0",
+    "feedparser>=6.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/qa/rss_resolver.py
+++ b/tests/qa/rss_resolver.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
+from typing import Any
 
-# Session cache: rss_feed_url -> resolved article url
-_CACHE: dict[str, str | None] = {}
+# Session cache: rss_feed_url -> list of article URLs (or None if feed failed)
+_CACHE: dict[str, list[str] | None] = {}
 
 _TIMEOUT = 10  # seconds
 
@@ -25,15 +26,14 @@ def resolve_article_url(rss_url: str) -> str | None:
     Returns None if the feed cannot be fetched or parsed.
     Results are cached in-process for the lifetime of the test session.
     """
-    if rss_url in _CACHE:
-        return _CACHE[rss_url]
-
-    url = _fetch_and_parse(rss_url)
-    _CACHE[rss_url] = url
-    return url
+    if rss_url not in _CACHE:
+        _CACHE[rss_url] = _fetch_and_parse_all(rss_url)
+    cached = _CACHE[rss_url]
+    return cached[0] if cached else None
 
 
-def _fetch_and_parse(rss_url: str) -> str | None:
+def _fetch_and_parse_all(rss_url: str) -> list[str] | None:
+    """Fetch RSS/Atom feed and return list of article URLs (most recent first)."""
     try:
         req = urllib.request.Request(
             rss_url,
@@ -53,45 +53,72 @@ def _fetch_and_parse(rss_url: str) -> str | None:
     except ET.ParseError:
         return None
 
+    urls: list[str] = []
+
     # RSS 2.0: <rss><channel><item><link>
-    # Try RSS first
     channel = root.find("channel")
     if channel is not None:
-        item = channel.find("item")
-        if item is not None:
+        for item in channel.findall("item"):
             link = item.findtext("link")
             if link and link.startswith("http"):
-                return link.strip()
+                urls.append(link.strip())
 
     # Atom: <feed><entry><link href="...">
     # Atom uses namespaces
-    entry = root.find(f"{{{_ATOM_NS}}}entry")
-    if entry is not None:
+    for entry in root.findall(f"{{{_ATOM_NS}}}entry"):
         link_el = entry.find(f"{{{_ATOM_NS}}}link")
         if link_el is not None:
             href = link_el.get("href", "")
             if href.startswith("http"):
-                return href.strip()
-
-    # RSS without namespace, or alternate element names
-    for item_tag in ("item", "entry"):
-        item = root.find(f".//{item_tag}")
-        if item is not None:
-            for link_tag in ("link", "url"):
-                link = item.findtext(link_tag)
-                if link and link.startswith("http"):
-                    return link.strip()
-            # Atom-style link element (no namespace match above)
-            link_el = item.find("link")
+                urls.append(href.strip())
+        # Fallback: look for <link> without namespace
+        else:
+            link_el = entry.find("link")
             if link_el is not None:
                 href = link_el.get("href", "")
                 if href.startswith("http"):
-                    return href.strip()
+                    urls.append(href.strip())
 
-    return None
+    # RSS without namespace, or alternate element names
+    if not urls:
+        for item_tag in ("item", "entry"):
+            for item in root.findall(f".//{item_tag}"):
+                for link_tag in ("link", "url"):
+                    link = item.findtext(link_tag)
+                    if link and link.startswith("http"):
+                        urls.append(link.strip())
+                # Atom-style link element (no namespace match above)
+                link_el = item.find("link")
+                if link_el is not None:
+                    href = link_el.get("href", "")
+                    if href.startswith("http"):
+                        urls.append(href.strip())
+
+    # Deduplicate while preserving order (most recent first)
+    seen = set()
+    deduped = []
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            deduped.append(url)
+    return deduped if deduped else None
 
 
-def resolve_site_url(site_spec: dict) -> str:
+def resolve_article_urls(rss_url: str, max_articles: int = 5) -> list[str]:
+    """Fetch *rss_url* and return up to *max_articles* most recent article URLs.
+
+    Returns empty list if the feed cannot be fetched or parsed.
+    Results are cached in-process for the lifetime of the test session.
+    """
+    if rss_url not in _CACHE:
+        _CACHE[rss_url] = _fetch_and_parse_all(rss_url)
+    cached = _CACHE[rss_url]
+    if not cached:
+        return []
+    return cached[:max_articles]
+
+
+def resolve_site_url(site_spec: dict[str, Any]) -> str:
     """Return the URL to use for testing *site_spec*.
 
     If the spec has an ``rss_feed`` key, fetches the feed and uses the
@@ -103,4 +130,5 @@ def resolve_site_url(site_spec: dict) -> str:
         resolved = resolve_article_url(rss_feed)
         if resolved:
             return resolved
-    return site_spec["url"]
+    url: str = site_spec["url"]
+    return url

--- a/tests/qa/test_real_urls.py
+++ b/tests/qa/test_real_urls.py
@@ -20,23 +20,17 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
+from typing import Any
 
 import pytest
 
-from tests.qa.reporter import save_result, validate_archive
-from tests.qa.rss_resolver import resolve_site_url
-
-# Timeout per site in seconds — generous to accommodate slow pages + monolith
-_ARCHIVE_TIMEOUT = 180
+from tests.qa.reporter import MIN_WORD_COUNT, QAResult, save_result, validate_archive
+from tests.qa.rss_resolver import resolve_article_urls, resolve_site_url
 
 
-@pytest.mark.real_url
-def test_archive_site(qa_site: dict, tmp_path: pytest.TempPathFactory) -> None:
-    """Archive a live site and validate the output."""
-    site_name = qa_site["name"]
-    url = resolve_site_url(qa_site)  # uses rss_feed if present, falls back to stored url
-    tags = qa_site.get("tags", {})
-
+def _run_archive(url: str, tmp_path: Path, site_name: str, tags: dict[str, str]) -> QAResult:
+    """Run archiveinator on url and return validation result."""
     # Run archiveinator as a subprocess — mirrors end-user experience
     proc = subprocess.run(
         [
@@ -77,6 +71,35 @@ def test_archive_site(qa_site: dict, tmp_path: pytest.TempPathFactory) -> None:
         ):
             result.bypass_method = method
             break
+
+    return result
+
+
+# Timeout per site in seconds — generous to accommodate slow pages + monolith
+_ARCHIVE_TIMEOUT = 180
+
+
+@pytest.mark.real_url
+def test_archive_site(qa_site: dict[str, Any], tmp_path: Path) -> None:
+    """Archive a live site and validate the output."""
+    site_name = qa_site["name"]
+    tags = qa_site.get("tags", {})
+
+    # Determine the initial URL (RSS feed article or fallback)
+    primary_url = resolve_site_url(qa_site)
+    result = _run_archive(primary_url, tmp_path, site_name, tags)
+
+    # If primary article is too short and we have an RSS feed, try alternate articles
+    if result.word_count < MIN_WORD_COUNT and qa_site.get("rss_feed"):
+        for alt_url in resolve_article_urls(qa_site["rss_feed"], max_articles=5)[
+            1:
+        ]:  # skip first (already tried)
+            if alt_url == primary_url:
+                continue
+            alt_result = _run_archive(alt_url, tmp_path, site_name, tags)
+            if alt_result.word_count >= MIN_WORD_COUNT:
+                result = alt_result
+                break
 
     # Persist result for summary table (works across xdist workers)
     save_result(result)

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "feedparser" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -72,6 +73,7 @@ dev = [
 requires-dist = [
     { name = "adblock", specifier = ">=0.6.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
+    { name = "feedparser", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "platformdirs", specifier = ">=4.0.0" },
@@ -268,6 +270,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "feedparser"
+version = "6.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sgmllib3k" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
 ]
 
 [[package]]
@@ -1099,6 +1113,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/e9/346d4d3fffc6871125e877dae8d9a1966b254fbd92a50f8561078b88b099/ruff-0.15.7-py3-none-win_amd64.whl", hash = "sha256:4d53d712ddebcd7dace1bc395367aec12c057aacfe9adbb6d832302575f4d3a1", size = 11755839, upload-time = "2026-03-19T16:26:19.897Z" },
     { url = "https://files.pythonhosted.org/packages/8f/e8/726643a3ea68c727da31570bde48c7a10f1aa60eddd628d94078fec586ff/ruff-0.15.7-py3-none-win_arm64.whl", hash = "sha256:18e8d73f1c3fdf27931497972250340f92e8c861722161a9caeb89a58ead6ed2", size = 11023304, upload-time = "2026-03-19T16:26:51.669Z" },
 ]
+
+[[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
 
 [[package]]
 name = "shellingham"

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "archiveinator"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "adblock" },


### PR DESCRIPTION
## Summary
- RSS resolver now returns multiple articles and caches feed results  
- QA tests retry with alternate articles if primary article word count < 300  
- page_load catches general PlaywrightError (not just timeouts)  
- Added feedparser dev dependency for RSS feed checking

## Test plan
- [x] All unit tests pass locally (191 passed)
- [x] RSS resolver correctly fetches multiple articles
- [x] Real-URL QA tests run with retry logic
- [ ] Wait for CI to pass on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)