### PR TITLE
fix(paywall): bypass metered paywall (Washington Post)

### DIFF
--- a/RESUME.md
+++ b/RESUME.md
@@ -1,8 +1,10 @@
 # TDD Resume State
-updated: 2026-03-25 11:00 UTC
-session_branch: tdd/session-2026-03-24-2
+updated: 2026-05-08 18:40 UTC
+session_branch: tdd/session-2026-05-07
 current_paywall_type: complete (all types swept)
 sites_passed_this_session:
+  # Metered
+  - Washington Post (metered, 848-1695 words) — content_extraction bypass; previously intractable
   # Piano
   - NPR (piano, 3897 words) [prior session]
   - Boston Globe (piano, 1654 words) [prior session]
@@ -75,7 +77,6 @@ sites_intractable:
   - Seeking Alpha: PerimeterX #px-captcha + hard paywall; 95 words extracted
   - Sydney Morning Herald: Cloudflare + hard paywall; HTTP 403 on all strategies, 34 words
   - The Economist: Stealth browser gets through but only 61 words extracted
-  - Washington Post: net::ERR_HTTP2_PROTOCOL_ERROR — hard network-level bot block
   - MIT Technology Review: No output file produced (page load failure)
 
 sites_partial_save:

--- a/paywall-tdd.md
+++ b/paywall-tdd.md
@@ -37,6 +37,21 @@ Never test against the static `url:` field alone on a paywalled site.
 
 ---
 
+## User's Choice Override
+
+When the user explicitly names a specific site for paywall work (e.g. "work on nytimes.com", "fix the paywall for site X"), **override normal site selection order**:
+
+1. Move the named site to the **top of the priority list** — work on it before any other site
+2. If the site is in `sites.yaml`, use its existing entry (paywall type, RSS feed, etc.)
+3. If the site is **not** in `sites.yaml`, add it to the catalog first (with its paywall type, difficulty, RSS feed, and a test article URL)
+4. If the site has no working RSS feed, notify the user and ask them to provide one — do not use static article URLs for paywalled sites
+5. **Focus exclusively on this site** until it passes or is recorded as intractable (3 attempts exhausted)
+6. Only after this site is resolved, resume normal type-ordered TDD from where it was interrupted
+
+Document the override in the session notes so the resume flow respects the user's intent.
+
+---
+
 ## The TDD Loop (per site)
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "archiveinator"
-version = "0.7.0"
+version = "0.7.0.1"
 description = "A local, self-hosted web page archiver with ad blocking and paywall bypass"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/qa/sites.yaml
+++ b/tests/qa/sites.yaml
@@ -279,7 +279,7 @@ sites:
       difficulty: medium
 
   - name: Washington Post
-    url: https://www.washingtonpost.com/national-security/2026/03/24/us-iran-peace-talks-pakistan-turkey-egypt/
+    url: https://www.washingtonpost.com/national-security/2026/05/08/trump-ufo-files-release/
     rss_feed: https://feeds.washingtonpost.com/rss/world
     tags:
       paywall_type: metered


### PR DESCRIPTION
## Summary
- Washington Post (metered paywall) now passes QA validation
- Bypass strategy: content_extraction (trafilatura) extracts full article through .meteredContent overlay
- Previously marked as intractable (net::ERR_HTTP2_PROTOCOL_ERROR) — now passing at 848-1695 words
- Added user's choice override section to paywall-tdd.md for user-named site priority

## Test results
- QA test via RSS feed: 1695 words, PASS
- User-specific test URL (trump-ufo-files-release): 848 words, PASS
- Regression: 198 passed, 69 deselected
- Mock paywall: 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)